### PR TITLE
Add schedule management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # test
+
 my test project
+
+## Schedule Module
+
+`schedule.py` provides a simple in-memory schedule manager. Example usage:
+
+```python
+from schedule import Schedule
+
+schedule = Schedule()
+
+# Add events
+schedule.add_event('Meeting', '2024-05-01', 'Team meeting')
+
+# List events
+for event in schedule.list_events():
+    print(event)
+
+# Remove an event
+schedule.remove_event('Meeting')
+```
+
+## Command-Line Interface
+
+Use `schedule_cli.py` to manage events from the command line. The script stores events in `schedule.json` by default.
+
+Add an event:
+
+```bash
+python schedule_cli.py add "Meeting" --date 2024-05-01 --description "Team meeting"
+```
+
+List events:
+
+```bash
+python schedule_cli.py list
+```
+
+Remove an event:
+
+```bash
+python schedule_cli.py remove "Meeting"
+```
+
+Specify a custom storage file with `--file` if needed.
+

--- a/schedule.py
+++ b/schedule.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+@dataclass
+class Event:
+    title: str
+    date: Optional[str] = None
+    description: Optional[str] = None
+
+class Schedule:
+    """Simple in-memory schedule manager."""
+
+    def __init__(self) -> None:
+        self.events: List[Event] = []
+
+    def add_event(self, title: str, date: Optional[str] = None, description: Optional[str] = None) -> Event:
+        """Add a new event to the schedule."""
+        event = Event(title=title, date=date, description=description)
+        self.events.append(event)
+        return event
+
+    def list_events(self) -> List[Event]:
+        """Return a list of all scheduled events."""
+        return list(self.events)
+
+    def remove_event(self, title: str) -> Event:
+        """Remove the first event matching the given title."""
+        for index, event in enumerate(self.events):
+            if event.title == title:
+                return self.events.pop(index)
+        raise ValueError(f"Event '{title}' not found")

--- a/schedule_cli.py
+++ b/schedule_cli.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+import os
+from typing import Optional
+
+from schedule import Schedule, Event
+
+DEFAULT_FILE = "schedule.json"
+
+
+def load_schedule(path: str) -> Schedule:
+    schedule = Schedule()
+    if os.path.exists(path):
+        with open(path, "r") as fh:
+            data = json.load(fh)
+        for item in data:
+            schedule.add_event(item["title"], item.get("date"), item.get("description"))
+    return schedule
+
+
+def save_schedule(schedule: Schedule, path: str) -> None:
+    with open(path, "w") as fh:
+        json.dump([event.__dict__ for event in schedule.list_events()], fh)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage scheduled events")
+    parser.add_argument("--file", default=DEFAULT_FILE, help="Path to schedule file")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add an event")
+    add_parser.add_argument("title")
+    add_parser.add_argument("--date")
+    add_parser.add_argument("--description")
+
+    subparsers.add_parser("list", help="List events")
+
+    remove_parser = subparsers.add_parser("remove", help="Remove an event")
+    remove_parser.add_argument("title")
+
+    args = parser.parse_args(argv)
+    schedule = load_schedule(args.file)
+
+    if args.command == "add":
+        event = schedule.add_event(args.title, args.date, args.description)
+        save_schedule(schedule, args.file)
+        print(f"Added: {event}")
+    elif args.command == "list":
+        for ev in schedule.list_events():
+            print(ev)
+    elif args.command == "remove":
+        event = schedule.remove_event(args.title)
+        save_schedule(schedule, args.file)
+        print(f"Removed: {event}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from schedule import Schedule
+
+
+def test_add_and_list_event():
+    s = Schedule()
+    s.add_event('Meeting', '2024-05-01', 'Team meeting')
+    events = s.list_events()
+    assert len(events) == 1
+    assert events[0].title == 'Meeting'
+    assert events[0].date == '2024-05-01'
+    assert events[0].description == 'Team meeting'
+
+
+def test_remove_event():
+    s = Schedule()
+    s.add_event('Task')
+    removed = s.remove_event('Task')
+    assert removed.title == 'Task'
+    assert s.list_events() == []
+
+
+def test_remove_event_not_found():
+    s = Schedule()
+    with pytest.raises(ValueError):
+        s.remove_event('Missing')

--- a/tests/test_schedule_cli.py
+++ b/tests/test_schedule_cli.py
@@ -1,0 +1,27 @@
+import os
+from schedule_cli import main, DEFAULT_FILE
+
+
+def test_cli_add_list_remove(tmp_path, capsys):
+    file_path = tmp_path / "sched.json"
+
+    # add event
+    main(["--file", str(file_path), "add", "Meeting", "--date", "2024-06-01"])
+    out = capsys.readouterr().out
+    assert "Added" in out
+
+    # list events
+    main(["--file", str(file_path), "list"])
+    out = capsys.readouterr().out
+    assert "Meeting" in out
+
+    # remove event
+    main(["--file", str(file_path), "remove", "Meeting"])
+    out = capsys.readouterr().out
+    assert "Removed" in out
+
+    # list again should be empty
+    main(["--file", str(file_path), "list"])
+    out = capsys.readouterr().out
+    assert out.strip() == ""
+


### PR DESCRIPTION
## Summary
- add `schedule.py` with a basic `Schedule` class
- document schedule usage in README
- add unit tests covering add/list/remove features
- add a command-line interface and README usage notes
- test CLI add/list/remove flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d3955b4083238fc3c6939563fad0